### PR TITLE
Fix touchscreen stuff and some other stuff

### DIFF
--- a/script.js
+++ b/script.js
@@ -2245,6 +2245,7 @@ document.addEventListener('click', handleClick);
 
 canvas.addEventListener('mousemove', function (e) {
 	if (document.pointerLockElement === canvas) {
+		console.log(game.tether)
 		if (game.tether.locked) game.tether.locked = false;
 		game.lastMousePosition.x += e.movementX;
 		game.lastMousePosition.y += e.movementY;

--- a/script.js
+++ b/script.js
@@ -828,7 +828,7 @@ function Tether() {
 	}
 
 	document.addEventListener('touchstart', handleTouch);
-	document.addEventListener('touchmove', handleTouch, {passive: false);
+	document.addEventListener('touchmove', handleTouch, {passive: false});
 
 	return this;
 }

--- a/script.js
+++ b/script.js
@@ -805,7 +805,6 @@ function Tether() {
 
 	document.addEventListener('touchend', function (e) {
 		self.locked = true;
-		game.lastMousePosition = {x: NaN, y: NaN};
 	});
 
 	function exitTether() {
@@ -2245,8 +2244,8 @@ document.addEventListener('click', handleClick);
 
 canvas.addEventListener('mousemove', function (e) {
 	if (document.pointerLockElement === canvas) {
-		console.log(game.tether)
 		if (game.tether.locked) game.tether.locked = false;
+		
 		game.lastMousePosition.x += e.movementX;
 		game.lastMousePosition.y += e.movementY;
 

--- a/script.js
+++ b/script.js
@@ -853,6 +853,7 @@ Tether.prototype.step = function () {
 	) {
 		canvas.requestPointerLock();
 		if (!(this.lastInteraction !== 'mouse' || document.pointerLockElement === canvas)) return;
+		
 		this.locked = false;
 
 		if (!game.started) {
@@ -2242,18 +2243,19 @@ function handleClick(e) {
 
 document.addEventListener('click', handleClick);
 
-	canvas.addEventListener('mousemove', function (e) {
-		if (document.pointerLockElement === canvas) {
-			game.lastMousePosition.x += e.movementX;
-			game.lastMousePosition.y += e.movementY;
+canvas.addEventListener('mousemove', function (e) {
+	if (document.pointerLockElement === canvas) {
+		if (game.tether.locked) game.tether.locked = false;
+		game.lastMousePosition.x += e.movementX;
+		game.lastMousePosition.y += e.movementY;
 
-			if (game.lastMousePosition.x < 0) game.lastMousePosition.x = 0;
-			else if (game.lastMousePosition.x > width) game.lastMousePosition.x = width;
+		if (game.lastMousePosition.x < 0) game.lastMousePosition.x = 0;
+		else if (game.lastMousePosition.x > width) game.lastMousePosition.x = width;
 
-			if (game.lastMousePosition.y < 0) game.lastMousePosition.y = 0;
-			else if (game.lastMousePosition.y > height) game.lastMousePosition.y = height;
-		}
-	});
+		if (game.lastMousePosition.y < 0) game.lastMousePosition.y = 0;
+		else if (game.lastMousePosition.y > height) game.lastMousePosition.y = height;
+	}
+});
 
 document.addEventListener('touchstart', function (e) {
 	lastTouchStart = new Date().getTime();

--- a/script.js
+++ b/script.js
@@ -828,7 +828,7 @@ function Tether() {
 	}
 
 	document.addEventListener('touchstart', handleTouch);
-	document.addEventListener('touchmove', handleTouch);
+	document.addEventListener('touchmove', handleTouch, {passive: false);
 
 	return this;
 }

--- a/script.js
+++ b/script.js
@@ -827,7 +827,7 @@ function Tether() {
 		game.lastMousePosition = {x: touch.clientX, y: touch.clientY};
 	}
 
-	document.addEventListener('touchstart', handleTouch);
+	document.addEventListener('touchstart', handleTouch, {passive: false});
 	document.addEventListener('touchmove', handleTouch, {passive: false});
 
 	return this;

--- a/style.css
+++ b/style.css
@@ -90,7 +90,3 @@ canvas {
 canvas.buttonhover {
   cursor: pointer;
 }
-
-canvas.hidecursor {
-  cursor: none;
-}


### PR DESCRIPTION
i added a "passive: false" property to the touchstart and touchmove listeners so that e.preventDefault works. chrome defaults the passive property to true, which doesn't make e.preventDefault work. on some browsers, there would be lag because the browser would be printing A LOT of errors in the console if e.preventDefault is used while passive is true.

secondly, the touchend listener doesn't make lastMousePosition equal to NaN, because then if the user switched to a mouse right after, the cursor would be teleported to the top left. if the lastMousePosition is set to NaN for a very important reason (it doesnt seem to), then maybe make two separate variables, lastMousePosition and lastTouchPosition, and use them accordingly.

lastly, i changed some indentation.

this should hopefully be my last pull request, i hope i didn't somehow break anything!